### PR TITLE
goods_controllerを編集

### DIFF
--- a/app/controllers/goods_controller.rb
+++ b/app/controllers/goods_controller.rb
@@ -12,8 +12,13 @@ class GoodsController < ApplicationController
   end
 
   def new
-    @good = Good.new
-    @good.good_images.new
+    if user_signed_in?
+      @good = Good.new
+      @good.good_images.new
+    else
+      flash[:alert] = "ログインしてください"
+      redirect_to root_path
+    end
   end
 
   def show
@@ -35,8 +40,7 @@ class GoodsController < ApplicationController
   end
 
   def update
-    @good.update_attributes(good_update_params)
-    if @good.update(good_update_params)
+    if @good.update_attributes(good_update_params)
       flash[:notice] = "商品の編集が完了しました"
     elsif upload_file.present?
       flash[:alert] = "商品の編集に失敗しました"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 2020_04_11_030537) do
     t.string "expanation", null: false
     t.string "shipping_date", null: false
     t.integer "delivery_method_id", null: false
-    t.string "trading_conditions", default: "未発送", null: false
+    t.integer "trading_conditions_id", default: 1, null: false
     t.integer "price", null: false
     t.bigint "category_id", null: false
     t.integer "size_id", null: false


### PR DESCRIPTION
#what
- 商品編集画面で画像を追加すると同じ画像が2回保存されている不具合を解消。
- 未ログイン状態で商品出品画面に行こうとするとトップページへリダイレクトし、アラートが出るように実装。

#why
- ユーザーの利便性向上のため
- 未ログイン状態で商品出品しようとするとuser_idがなくエラーとなってしまうのを防ぐため。